### PR TITLE
Correct node? function and make public

### DIFF
--- a/doc/design/01-merging-rewrite-clj-and-rewrite-cljs.adoc
+++ b/doc/design/01-merging-rewrite-clj-and-rewrite-cljs.adoc
@@ -52,42 +52,57 @@ Rewrite-cljc is a merge of https://github.com/xsc/rewrite-clj[rewrite-clj] and h
 
 From what I perceive as public APIs, rewrite-clj has gained:
 
-[cols="2,3"]
+[cols="3,1,3"]
 |===
-| public | description
+| public | origin | description
+
+| rewrite-cljc.node/node?
+| new
+| returns true if element is a rewrite-cljc created node
 
 | rewrite-cljc.paredit
-| structured editing of S-expression data formerly in rewrite-cljs only
+| rewrite-cljs
+| API for structured editing of S-expression data
 
 | rewrite-cljc.zip/append-child*
-| formerly internal only and omitted, I assume, by accident
+| internal
+| accidental omission from public API
 
 | rewrite-cljc.zip/find-last-by-pos
-| positional search support formerly in rewrite-cljs only
+| rewrite-cljs
+| positional search support
 
 | rewrite-cljc.zip/find-tag-by-pos
-| positional search support formerly in rewrite-cljs only
+| rewrite-cljs
+| positional search support
 
 | rewrite-cljc.zip/insert-newline-left
-| formerly internal only and omitted, I assume, by accident
+| internal
+| accidental omission from public API
 
 | rewrite-cljc.zip/insert-newline-right
-| formerly omitted, I assume, by accident
+| internal
+| accidental omission from public API
 
 | rewrite-cljc.zip/insert-space-left
-| formerly internal only and omitted, I assume, by accident
+| internal
+| accidental omission from public API
 
 | rewrite-cljc.zip/insert-space-right
-| formerly internal only and omitted, I assume, by accident
+| internal
+| accidental omission from public API
 
 | rewrite-cljc.zip/position-span
-| positional search support formerly in rewrite-cljs only
+| rewrite-cljs
+| positional search support
 
 | rewrite-cljc.zip/remove-preserve-newline
-| formerly in rewrite-cljs only
+| rewrite-cljs
+| same as remove but preserves newlines
 
 | rewrite-cljc.zip/subzip
-| formerly internal only, found useful to expose
+| internal
+| operate on a sub tree without affecting location
 |===
 
 And rewrite-cljs has gained all of rewrite-clj's features except for the ability to read from files.

--- a/src/rewrite_cljc/node.cljc
+++ b/src/rewrite_cljc/node.cljc
@@ -35,6 +35,7 @@
   inner?
   leader-length
   length
+  node?
   printable-only?
   replace-children
   sexpr

--- a/src/rewrite_cljc/node/protocols.cljc
+++ b/src/rewrite_cljc/node/protocols.cljc
@@ -75,6 +75,12 @@
   (when (inner? node)
     (sexprs (children node))))
 
+
+(defn node?
+  "Returns true if `x` is a rewrite-cljc created node."
+  [ x ]
+  (not= :unknown (tag x)))
+
 ;; ## Coerceable
 
 (defprotocol+ NodeCoerceable
@@ -165,6 +171,3 @@
   [[row col] [row-extent col-extent]]
   [(+ row row-extent)
    (cond-> col-extent (zero? row-extent) (+ col))])
-
-(defn ^:no-doc node? [ x ]
-  (satisfies? Node x))

--- a/test/rewrite_cljc/node_test.cljc
+++ b/test/rewrite_cljc/node_test.cljc
@@ -52,3 +52,11 @@
                       [cljs-time.format :as tf]]))"
           res (p/parse-string sample)]
       (is (= sample (n/string res))))))
+
+(deftest t-node?
+  (is (not (n/node? 42)))
+  (is (not (n/node? "just a string")))
+  (is (not (n/node? {:a 1})))
+  (is (not (n/node? (first {:a 1}))))
+  (is (n/node? (n/list-node (list 1 2 3))))
+  (is (n/node? (n/string-node "123"))))


### PR DESCRIPTION
I had previously factored out verification that an element
was a rewrite-cljc created node from tests to a "node?" function.

Thing is, the test was never correct.

Rewrite-clj, and therefore rewrite-cljc, extends Object to a Node.
I'm not entirely clear why it does this, but assume it is important.
This means any object will return true for `satisfies?` Node, which
is not helpful for a node? fn.

I added some tests for "node?" and updated it to return true only
for rewrite-clj created nodes.

I also decided to expose this function under the node API.